### PR TITLE
Update Next.js integration docs to use <Html />

### DIFF
--- a/packages/website/src/docs/getting-started.mdx
+++ b/packages/website/src/docs/getting-started.mdx
@@ -93,7 +93,7 @@ npm install bumbag-server
 Open up your `_document.js` file, and add the following:
 
 ```jsx
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document, { Head, Html, Main, NextScript } from 'next/document'
 import { extractCritical } from 'bumbag-server'
 import { InitializeColorMode } from 'bumbag'
 
@@ -117,14 +117,14 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html>
+      <Html>
         <Head />
         <body>
           <InitializeColorMode />
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
[The latest Next.js docs](https://nextjs.org/docs/advanced-features/custom-document) say to wrap the app with its exported `<Html />` component:

```js
import Document, { Html, Head, Main, NextScript } from 'next/document'

class MyDocument extends Document {
  static async getInitialProps(ctx) {
    const initialProps = await Document.getInitialProps(ctx)
    return { ...initialProps }
  }

  render() {
    return (
      <Html>
        <Head />
        <body>
          <Main />
          <NextScript />
        </body>
      </Html>
    )
  }
}

export default MyDocument
```

(https://nextjs.org/docs/advanced-features/custom-document)

Updating our docs to reflect this.